### PR TITLE
composer.json: fix deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         "ext-json": "*",
         "api-platform/core": "^2.6",
         "composer/package-versions-deprecated": "1.11.99.1",
-        "doctrine/annotations": "^1.0",
-        "doctrine/doctrine-bundle": "^2.2",
-        "doctrine/doctrine-migrations-bundle": "^3.0",
+        "doctrine/annotations": "~1.13.1",
+        "doctrine/doctrine-bundle": "~2.4.1",
+        "doctrine/doctrine-migrations-bundle": "~3.1.1",
         "doctrine/orm": "^2.8",
         "league/csv": "^9.7",
         "lexik/jwt-authentication-bundle": "^2.11",
@@ -47,7 +47,7 @@
         "liip/test-fixtures-bundle": "^1.11",
         "symfony/browser-kit": "5.2.*",
         "symfony/http-client": "5.2.*",
-        "symfony/maker-bundle": "^1.29",
+        "symfony/maker-bundle": "~1.31.1",
         "symfony/phpunit-bridge": "^5.2"
     },
     "config": {


### PR DESCRIPTION
These semver strings worked two years ago, but installing now on a fresh machine they evaluate to versions that don't work for us due to PHP 8.1+ requirements among other things.

Pinning the versions to patch releases that match those currently installed on production.